### PR TITLE
Simple server with database

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+
+target/
+Cargo.lock
+
+.env

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "openedx-admin-backend"
+version = "0.1.0"
+authors = ["dikuchan <dikuchan@yahoo.com>"]
+edition = "2018"
+
+[dependencies]
+actix-web = "2.0"
+actix-rt = "1.0"
+
+# JSON serialization/deserialization.
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+json = "0.12"
+
+# Logging.
+dotenv = "0.15"
+log = "0.4"
+env_logger = "0.7.1"
+
+# ORM.
+diesel = { version = "1.4.5", features = ["postgres", "r2d2", "chrono"] }
+chrono = { version = "0.4.10", features = ["serde"] }
+r2d2 = "0.8.9"

--- a/backend/diesel.toml
+++ b/backend/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"

--- a/backend/src/api/auth.rs
+++ b/backend/src/api/auth.rs
@@ -1,0 +1,20 @@
+use crate::{
+    Pool,
+    models::User,
+    schema::users::dsl::*,
+};
+use diesel::RunQueryDsl;
+use actix_web::{web, HttpResponse};
+
+fn get_users(pool: web::Data<Pool>) -> Result<Vec<User>, diesel::result::Error> {
+    let connection = pool.get().unwrap();
+    let items = users.load::<User>(&connection)?;
+    Ok(items)
+}
+
+pub async fn hello(db: web::Data<Pool>) -> Result<HttpResponse, actix_web::Error> {
+    Ok(web::block(move || get_users(db))
+        .await
+        .map(|user| HttpResponse::Ok().json(user))
+        .map_err(|_| HttpResponse::InternalServerError())?)
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,0 +1,48 @@
+#[macro_use]
+extern crate diesel;
+
+use std::env;
+use actix_web::{
+    web, App, HttpServer,
+    middleware::Logger,
+};
+use env_logger::Env;
+use diesel::{
+    prelude::*,
+    r2d2::{self, ConnectionManager},
+};
+
+mod api;
+mod schema;
+mod models;
+
+pub type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
+
+fn create_dbcp() -> Pool {
+    dotenv::dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL should be set");
+    let manager = ConnectionManager::<PgConnection>::new(database_url);
+    r2d2::Pool::builder()
+        .build(manager)
+        .expect("Failed to create pool")
+}
+
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::from_env(Env::default().default_filter_or("info"))
+        .init();
+
+    let pool = create_dbcp();
+
+    HttpServer::new(move || {
+        App::new()
+            .data(pool.clone())
+            .route("/hello", web::get().to(api::auth::hello))
+            .wrap(Logger::default())
+    })
+        .bind("localhost:8080")?
+        .run()
+        .await
+}

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,0 +1,18 @@
+use super::schema::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Queryable)]
+pub struct User {
+    pub id: i32,
+    pub login: String,
+    pub email: String,
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[derive(Insertable, Debug)]
+#[table_name = "users"]
+pub struct NewUser<'a> {
+    pub login: &'a str,
+    pub email: &'a str,
+    pub created_at: chrono::NaiveDateTime,
+}

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1,0 +1,8 @@
+table! {
+    users (id) {
+        id -> Int4,
+        login -> Text,
+        email -> Text,
+        created_at -> Timestamp,
+    }
+}


### PR DESCRIPTION
Using Actix as web framework and [Diesel](https://diesel.rs/) as ORM for Postgres.

In the current state, building procces is complicated and not automated. To successfuly build the server, reproduce next steps (would be useful for @FortyWays):
1. Install cargo via `rustup` (using [official site](https://rustup.rs/), distro package, [Docker](https://hub.docker.com/_/rust) or whatever).
2. Install `postgresql-devel` (name depends on your distro) package in order for Diesel to link during linkage.
3. Download [Docker image](https://hub.docker.com/_/postgres) for Postgres.
4. Start a new Postgres instance. For example,
```
$ docker run -d \
    --name openedx-admin \
    -e POSTGRES_USER=deerc-dev
    -e POSTGRES_PASSWORD=kommsussertod \
    postgres
```
5. Set environmental variable `DATABASE_URL`. For example,
```
DATABASE_URL=postgres://deerc-dev:kommsussertod@172.17.0.2:5432/openedx-admin
```
Where username and password are the same as in the previous step, IP could be retrieved from Docker and name of the database is custom. Or, as an alternative, variable can be specified in `.env` file in the `backend` directory.
6. Run `cargo run` in the `backend` directory. It should successfuly compile and print that it started _n_ workers and a service on localhost. For example,
```
[2020-07-27T21:43:17Z INFO  actix_server::builder] Starting 4 workers
[2020-07-27T21:43:17Z INFO  actix_server::builder] Starting "actix-web-service-127.0.0.1:8080" service on 127.0.0.1:8080
```
7. Check via Postman if request on `localhost:8080/hello` has status 200.

Additionaly, you can fill the database with sample data. View table structure with DataGrid, for example, then add a new field. JSON response should return all fields in the table.